### PR TITLE
8t2au9: Add support for youtube videos in Sanity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A fundraising site for a great cause
 
-## To Run the project:
+## To Run the project for the first time:
 
 - Install lerna globally (postinstall script uses it)
 
@@ -12,10 +12,18 @@ A fundraising site for a great cause
 
 `npm install --g @sanity/cli`
 
-- Run npm install inside the sanity folder
-
-`cd sanity && npm install`
-
 - Install concurrently globally
 
 `npm install -g concurrently`
+
+- Install project dependencies
+
+`npm install`
+
+- Build the project to get Sanity initialized locally
+
+`npm run build`
+
+- Run the development servers for NextJs and Sanity
+
+`npm run dev`

--- a/lib/sanity.js
+++ b/lib/sanity.js
@@ -5,6 +5,8 @@ import {
   createPreviewSubscriptionHook,
 } from 'next-sanity'
 
+import { serializers } from './serializers'
+
 const config = {
   /**
    * Find your project ID and dataset in `sanity.json` in your studio project.
@@ -44,7 +46,7 @@ export const PortableText = createPortableTextComponent({
   ...config,
   // Serializers passed to @sanity/block-content-to-react
   // (https://github.com/sanity-io/block-content-to-react)
-  serializers: {},
+  serializers: { serializers },
 })
 
 // Set up the client for fetching data in the getProps page functions

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -4,6 +4,7 @@ import YouTube from 'react-youtube'
 
 export const serializers = {
   types: {
+    // eslint-disable-next-line react/display-name
     youtube: ({ node }) => {
       const { url } = node
       const id = getYouTubeId(url)

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import getYouTubeId from 'get-youtube-id'
+import YouTube from 'react-youtube'
+
+export const serializers = {
+  types: {
+    youtube: ({ node }) => {
+      const { url } = node
+      const id = getYouTubeId(url)
+      return <YouTube videoId={id} />
+    },
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5945,6 +5945,11 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
     },
+    "get-youtube-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-youtube-id/-/get-youtube-id-1.0.1.tgz",
+      "integrity": "sha512-5yidLzoLXbtw82a/Wb7LrajkGn29BM6JuLWeHyNfzOGp1weGyW4+7eMz6cP23+etqj27VlOFtq8fFFDMLq/FXQ=="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -7238,6 +7243,11 @@
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
       }
+    },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-utils": {
       "version": "1.2.3",
@@ -9380,6 +9390,16 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-youtube": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-youtube/-/react-youtube-7.13.1.tgz",
+      "integrity": "sha512-b++TLHmHDpd0ZBS1wcbYabbuchU+W4jtx5A2MUQX0BINNKKsaIQX29sn/aLvZ9v5luwAoceia3VGtyz9blaB9w==",
+      "requires": {
+        "fast-deep-equal": "3.1.3",
+        "prop-types": "15.7.2",
+        "youtube-player": "5.5.2"
+      }
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -9874,6 +9894,11 @@
           "dev": true
         }
       }
+    },
+    "sister": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
+      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
     },
     "slash": {
       "version": "3.0.0",
@@ -11294,6 +11319,16 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "youtube-player": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+      "requires": {
+        "debug": "^2.6.6",
+        "load-script": "^1.0.0",
+        "sister": "^3.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
   "dependencies": {
     "concurrently": "^6.2.1",
     "faunadb": "^4.3.0",
+    "get-youtube-id": "^1.0.1",
     "next": "^11.1.0",
     "next-sanity": "^0.4.0",
     "next-share": "^0.12.1",
     "pure-react-carousel": "^1.27.6",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-icons": "^4.2.0"
+    "react-icons": "^4.2.0",
+    "react-youtube": "^7.13.1"
   },
   "devDependencies": {
     "@sanity/cli": "^2.15.0",

--- a/sanity/schemas/blockContent.js
+++ b/sanity/schemas/blockContent.js
@@ -21,21 +21,21 @@ export default {
       // you want and decide how you want to deal with it where you want to
       // use your content.
       styles: [
-        {title: 'Normal', value: 'normal'},
-        {title: 'H1', value: 'h1'},
-        {title: 'H2', value: 'h2'},
-        {title: 'H3', value: 'h3'},
-        {title: 'H4', value: 'h4'},
-        {title: 'Quote', value: 'blockquote'},
+        { title: 'Normal', value: 'normal' },
+        { title: 'H1', value: 'h1' },
+        { title: 'H2', value: 'h2' },
+        { title: 'H3', value: 'h3' },
+        { title: 'H4', value: 'h4' },
+        { title: 'Quote', value: 'blockquote' },
       ],
-      lists: [{title: 'Bullet', value: 'bullet'}],
+      lists: [{ title: 'Bullet', value: 'bullet' }],
       // Marks let you mark up inline text in the block editor.
       marks: {
         // Decorators usually describe a single property – e.g. a typographic
         // preference or highlighting by editors.
         decorators: [
-          {title: 'Strong', value: 'strong'},
-          {title: 'Emphasis', value: 'em'},
+          { title: 'Strong', value: 'strong' },
+          { title: 'Emphasis', value: 'em' },
         ],
         // Annotations can be any object structure – e.g. a link or a footnote.
         annotations: [
@@ -59,7 +59,8 @@ export default {
     // as a block type.
     {
       type: 'image',
-      options: {hotspot: true},
+      options: { hotspot: true },
     },
+    { type: 'youtube' },
   ],
 }

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -9,6 +9,7 @@ import blockContent from './blockContent'
 import category from './category'
 import post from './post'
 import author from './author'
+import youtube from './youtube'
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
@@ -25,5 +26,6 @@ export default createSchema({
     // When added to this list, object types can be used as
     // { type: 'typename' } in other document schemas
     blockContent,
+    youtube,
   ]),
 })

--- a/sanity/schemas/youtube.js
+++ b/sanity/schemas/youtube.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import getYouTubeId from 'get-youtube-id'
+import YouTube from 'react-youtube'
+
+const YoutubePreview = ({ value }) => {
+  const { url } = value
+  const id = getYouTubeId(url)
+  return <YouTube videoId={id} />
+}
+
+export default {
+  name: 'youtube',
+  type: 'object',
+  title: 'Youtube Video',
+  fields: [
+    {
+      name: 'url',
+      type: 'url',
+      title: 'URL',
+    },
+  ],
+  preview: {
+    select: {
+      url: 'url',
+    },
+    component: YoutubePreview,
+  },
+}


### PR DESCRIPTION
This PR:

- Adds a new "youtube" data schema 
- Configures the preview of the video
- Update Readme

Just followed this:
https://www.sanity.io/guides/portable-text-how-to-add-a-custom-youtube-embed-block#2a956766a178

![image](https://user-images.githubusercontent.com/42892230/132262877-b8ec3a77-7e2d-42d2-8130-d5e003bea230.png)
